### PR TITLE
Add UserNotFoundException in UserService

### DIFF
--- a/src/test/java/me/parkjeounghyun/springbootdeveloper/service/UserServiceTest.java
+++ b/src/test/java/me/parkjeounghyun/springbootdeveloper/service/UserServiceTest.java
@@ -1,0 +1,29 @@
+package me.parkjeounghyun.springbootdeveloper.service;
+
+import lombok.RequiredArgsConstructor;
+import me.parkjeounghyun.springbootdeveloper.config.error.exception.UserNotFoundException;
+import me.parkjeounghyun.springbootdeveloper.domain.User;
+import me.parkjeounghyun.springbootdeveloper.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    UserService userService;
+
+    @DisplayName("findById: 없는 유저의 아이디를 찾으면 UserNotFoundException이 발생한다.")
+    @Test
+    public void userNotFound() {
+        // then
+        Assertions.assertThrows(UserNotFoundException.class, () -> {
+            userService.findById(1L);
+        });
+    }
+}


### PR DESCRIPTION
UserService 테스트 생성
- findById로 없는 존재하지 않는 유저 id 를 파라미터로 넘겨줬을 때 UserNotFoundException 발생 테스트 코드 작성